### PR TITLE
Fix metastation appearing when it shouldn't

### DIFF
--- a/tgstation.dme
+++ b/tgstation.dme
@@ -14,7 +14,6 @@
 
 // BEGIN_INCLUDE
 #include "_maps\_basemap.dm"
-#include "_maps\map_files\MetaStation\MetaStation.dmm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DEFINES\_globals.dm"


### PR DESCRIPTION
It is advised to not tick any dmms in the dme as the dynamic map loader
should take care of them for you