### PR TITLE
Add a delay between sounds produced by emotes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -65,8 +65,9 @@
 	msg = "<b>[user]</b> " + msg
 
 	var/tmp_sound = get_sound(user)
-	if(tmp_sound && (!only_forced_audio || !intentional))
+	if(tmp_sound && (!only_forced_audio || !intentional) && (user.sound_time + user.sound_delay) <= world.time)
 		playsound(user, tmp_sound, 50, vary)
+		user.sound_time = world.time
 
 	for(var/mob/M in GLOB.dead_mob_list)
 		if(!M.client || isnewplayer(M))

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -99,6 +99,9 @@
 
 	var/list/progressbars = null	//for stacking do_after bars
 
+	var/sound_time = 0 //sound emote stuff (aka. the ree fix 4 years later)
+	var/sound_delay = 10 //1 second should be enough between sounds
+
 	var/list/mousemove_intercept_objects
 
 	var/datum/click_intercept


### PR DESCRIPTION
Effectively reimplements the cooldown from https://github.com/Riesen/-tg-station/pull/10 almost 4 years later and stops sound files played by emotes from overlapping
Should eventually turn the delay var into a define but it's good enough for now