### PR TITLE
Give emags to saboteurs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -628,6 +628,7 @@
 		/obj/item/destTagger/borg,
 		/obj/item/stack/cable_coil/cyborg,
 		/obj/item/pinpointer/syndicate_cyborg,
+		/obj/item/card/emag,
 		/obj/item/borg_chameleon,
 		)
 	ratvar_modules = list(


### PR DESCRIPTION
The other syndieborgs get it, so why not the borgs specifically designed for sabotage?