### PR TITLE
Fix precision_coeff never getting set in dna scanners

### DIFF
--- a/code/game/machinery/dna_scanner.dm
+++ b/code/game/machinery/dna_scanner.dm
@@ -22,10 +22,10 @@
 	precision_coeff = 0
 	for(var/obj/item/stock_parts/scanning_module/P in component_parts)
 		scan_level += P.rating
-	for(var/obj/item/stock_parts/manipulator/P in component_parts)
-		precision_coeff = P.rating
+	for(var/obj/item/stock_parts/matter_bin/P in component_parts)
+		precision_coeff += P.rating
 	for(var/obj/item/stock_parts/micro_laser/P in component_parts)
-		damage_coeff = P.rating
+		damage_coeff += P.rating
 
 /obj/machinery/dna_scannernew/examine(mob/user)
 	..()


### PR DESCRIPTION
Manipulators got changed to matter bins and nobody edited the refresh_parts to make it work, this fixes the joker timer on upgraded scanners