### PR TITLE
Make perma food vendor vend food to prisoners

### DIFF
--- a/code/modules/vending/sustenance.dm
+++ b/code/modules/vending/sustenance.dm
@@ -14,6 +14,7 @@
 	refill_canister = /obj/item/vending_refill/sustenance
 	default_price = 0
 	extra_price = 0
+	onstation = FALSE //makes it free to buy things from it
 	payment_department = NO_FREEBIES
 
 /obj/item/vending_refill/sustenance


### PR DESCRIPTION
As it is right now, prisoner IDs don't have an account and therefore can't buy the $0 food items on it, this fixes that