### PR TITLE
Update brain_trauma.dm

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -2,6 +2,8 @@
 	name = "Spontaneous Brain Trauma"
 	typepath = /datum/round_event/brain_trauma
 	weight = 25
+	
+    min_players = 10
 
 /datum/round_event/brain_trauma
 	fakeable = FALSE


### PR DESCRIPTION
## About The Pull Request
The PR adds a player count requirement of 10 to the spontaneous brain trauma event.

## Changelog
:cl:
tweak: The spontaneous brain trauma event now only occurs if there's 10 players or more in the server. 
/:cl: