### PR TITLE
brain trauma event changes

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -3,6 +3,9 @@
 	typepath = /datum/round_event/brain_trauma
 	weight = 25
 
+	earliest_start = 60 MINUTES
+	min_players = 5 //serb dead
+
 /datum/round_event/brain_trauma
 	fakeable = FALSE
 


### PR DESCRIPTION
## Changelog
:cl:
tweak: The spontaneous brain trauma random event only occurs with at least 5 players and at least 60 minutes into the round
/:cl:
## Why It's Good For The Game
It means the spontaneous brain trauma event happens less often.


