### PR TITLE
BugFix - Spillable Flag on Bottles of Alcohol

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -256,6 +256,7 @@
 	icon_state = "beer"
 	list_reagents = list("beer" = 30)
 	foodtype = GRAIN | ALCOHOL
+	spillable = TRUE //allows Reagents to splash upon smash
 
 /obj/item/reagent_containers/food/drinks/beer/light
 	name = "Carp Lite"
@@ -269,6 +270,7 @@
 	item_state = "beer"
 	list_reagents = list("ale" = 30)
 	foodtype = GRAIN | ALCOHOL
+	spillable = TRUE //allows Reagents to splash upon smash
 
 /obj/item/reagent_containers/food/drinks/sillycup
 	name = "paper cup"

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -13,6 +13,7 @@
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	var/const/duration = 13 //Directly relates to the 'knockdown' duration. Lowered by armor (i.e. helmets)
 	isGlass = TRUE
+	spillable = TRUE //allows Reagents to splash upon smash
 	foodtype = ALCOHOL
 
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This is a small commit that adds the `spillable` flag to bottles of alcohol as well as ale and beer, which allows the Reagents inside the bottle to be splashed on the target.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This fixes a bug that prevented the reagents of such bottles from splashing. Splashing of Reagents from such containers is definitely intended, as the `/obj/item/reagent_containers/food/drinks/bottle/attack(mob/living/target, mob/living/user)` proc calls `SplashReagents()`, however `SplashReagents()` checks the `spillable` flag, which was not set to true by default for bottles of alcohol

## Changelog
:cl:
fix: set `spillable` flag to `true` for `ale`, `beer`, and `bottle` items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
